### PR TITLE
refactor: remove cleanup job from deploy-cloudflare workflow and upda…

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -231,13 +231,4 @@ jobs:
           echo "📍 Deployment URLs:"
           terraform output -json | jq -r 'to_entries[] | select(.key | endswith("_worker_url")) | "- \(.key | gsub("_worker_url$"; "")): \(.value)"'
 
-  cleanup:
-    needs: deploy
-    runs-on: ubuntu-latest
-    if: always()
-    
-    steps:
-      - name: Clean up artifacts
-        uses: geekyeggo/delete-artifact@v2
-        with:
-          name: dist 
+  # Cleanup job removed - artifacts have retention-days: 5 set, so GitHub will automatically clean them up 

--- a/apps/petstore-api/src/main.ts
+++ b/apps/petstore-api/src/main.ts
@@ -199,7 +199,7 @@ class PetstoreApiServer {
       const transport = new StdioServerTransport();
       await this.server.connect(transport);
 
-      this.logger.info('Petstore API MCP server started successfully');
+      this.logger.info('Petstore API MCP server started successfully!');
       
       // Pre-load the OpenAPI spec in the background
       this.openApiLoader.loadSpec().catch((error) => {


### PR DESCRIPTION
…te server startup log message

- Removed the cleanup job from the deploy-cloudflare workflow as GitHub now automatically manages artifact cleanup with a retention period.
- Updated the server startup log message in PetstoreApiServer to include an exclamation mark for improved emphasis.