### PR TITLE
fix: correct output variable name in deploy-cloudflare workflow

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -28,7 +28,7 @@ jobs:
   detect-affected:
     runs-on: ubuntu-latest
     outputs:
-      affected-apps: ${{ steps.affected.outputs.apps }}
+      affected-apps: ${{ steps.affected.outputs.affected-apps }}
       has-affected: ${{ steps.affected.outputs.has-affected }}
     
     steps:

--- a/apps/petstore-api/src/main.ts
+++ b/apps/petstore-api/src/main.ts
@@ -199,7 +199,7 @@ class PetstoreApiServer {
       const transport = new StdioServerTransport();
       await this.server.connect(transport);
 
-      this.logger.info('Petstore API MCP server started successfully!');
+      this.logger.info('Petstore API MCP server started successfully');
       
       // Pre-load the OpenAPI spec in the background
       this.openApiLoader.loadSpec().catch((error) => {


### PR DESCRIPTION
- Updated the output variable name from 'apps' to 'affected-apps' for clarity in the deploy-cloudflare workflow.