### PR TITLE
fix: update Terraform Makefile and environment variable configurations

### DIFF
--- a/apps/petstore-api/src/main.ts
+++ b/apps/petstore-api/src/main.ts
@@ -199,7 +199,7 @@ class PetstoreApiServer {
       const transport = new StdioServerTransport();
       await this.server.connect(transport);
 
-      this.logger.info('Petstore API MCP server started successfully');
+      this.logger.info('Petstore API MCP server started successfully!');
       
       // Pre-load the OpenAPI spec in the background
       this.openApiLoader.loadSpec().catch((error) => {

--- a/infrastructure/terraform/Makefile
+++ b/infrastructure/terraform/Makefile
@@ -4,8 +4,11 @@
 # Default environment
 ENV ?= dev
 
-# Terraform variables file based on environment
-TF_VARS := -var-file=environments/$(ENV).tfvars
+# Terraform variables files
+# Note: terraform.tfvars.local should contain your Cloudflare credentials for local development
+TF_VARS := -var-file=terraform.tfvars
+TF_VARS += $(wildcard terraform.tfvars.local)
+TF_VARS += -var-file=environments/$(ENV).tfvars
 
 # Help target
 help:
@@ -30,6 +33,9 @@ help:
 	@echo "Examples:"
 	@echo "  make plan ENV=dev"
 	@echo "  make apply ENV=production"
+	@echo ""
+	@echo "Note: Create terraform.tfvars.local with your Cloudflare credentials"
+	@echo "      for local development. See README.md for details."
 
 # Initialize Terraform
 init:

--- a/infrastructure/terraform/README.md
+++ b/infrastructure/terraform/README.md
@@ -1,0 +1,71 @@
+# Terraform Infrastructure for MCP Servers
+
+This directory contains Terraform configuration for deploying MCP servers to Cloudflare Workers.
+
+## GitHub Secrets Setup
+
+The following secrets must be configured in your GitHub repository for CI/CD deployments:
+
+- `CLOUDFLARE_API_TOKEN`: Your Cloudflare API token with permissions to manage Workers
+  - Create at: https://dash.cloudflare.com/profile/api-tokens
+  - Required permissions: Account:Cloudflare Workers Scripts:Edit
+  
+- `CLOUDFLARE_ACCOUNT_ID`: Your Cloudflare account ID
+  - Find in your Cloudflare dashboard URL or account settings
+
+## Local Development
+
+For local Terraform operations, create a `terraform.tfvars.local` file:
+
+```hcl
+# terraform.tfvars.local
+cloudflare_api_token  = "your-actual-40-character-api-token"
+cloudflare_account_id = "your-actual-32-character-account-id"
+```
+
+This file is gitignored and will not be committed to the repository.
+
+## Usage
+
+### Initialize Terraform
+```bash
+terraform init
+```
+
+### Plan changes
+```bash
+# For staging environment
+terraform plan -var-file=terraform.tfvars -var-file=terraform.tfvars.local -var-file=environments/staging.tfvars
+
+# For production environment
+terraform plan -var-file=terraform.tfvars -var-file=terraform.tfvars.local -var-file=environments/production.tfvars
+```
+
+### Apply changes
+```bash
+# For staging environment
+terraform apply -var-file=terraform.tfvars -var-file=terraform.tfvars.local -var-file=environments/staging.tfvars
+
+# For production environment
+terraform apply -var-file=terraform.tfvars -var-file=terraform.tfvars.local -var-file=environments/production.tfvars
+```
+
+## CI/CD Deployment
+
+The GitHub Actions workflow automatically:
+1. Detects affected MCP server applications
+2. Builds and tests them
+3. Generates Terraform configuration for affected apps
+4. Deploys to the appropriate environment based on the branch:
+   - `main` → production
+   - `develop` → staging
+   - Pull requests → dev (plan only, no apply)
+
+## Environment-Specific Configuration
+
+Each environment has its own configuration file in `environments/`:
+- `dev.tfvars`
+- `staging.tfvars`
+- `production.tfvars`
+
+These files contain environment-specific settings like routes, environment variables, and KV namespaces for each MCP server. 

--- a/infrastructure/terraform/environments/mcp-server-config.example.tfvars
+++ b/infrastructure/terraform/environments/mcp-server-config.example.tfvars
@@ -10,24 +10,24 @@ petstore_api_routes = [
 ]
 
 petstore_api_env_vars = {
-  NODE_ENV        = "production"
-  API_VERSION     = "v1"
-  LOG_LEVEL       = "info"
-  CORS_ORIGIN     = "https://example.com"
-  RATE_LIMIT      = "1000"
-  
+  NODE_ENV    = "production"
+  API_VERSION = "v1"
+  LOG_LEVEL   = "info"
+  CORS_ORIGIN = "https://example.com"
+  RATE_LIMIT  = "1000"
+
   # MCP-specific settings
-  MCP_AUTH_TOKEN  = "your-secret-token"  # Optional authentication
-  MCP_MAX_TIMEOUT = "30000"              # Max timeout in ms
+  MCP_AUTH_TOKEN  = "your-secret-token" # Optional authentication
+  MCP_MAX_TIMEOUT = "30000"             # Max timeout in ms
 }
 
 petstore_api_kv_namespaces = [
   {
-    binding = "RATE_LIMITER"  # For rate limiting
+    binding = "RATE_LIMITER" # For rate limiting
     id      = "your-kv-namespace-id"
   },
   {
-    binding = "CACHE"         # For caching responses
+    binding = "CACHE" # For caching responses
     id      = "your-cache-namespace-id"
   }
 ]
@@ -43,10 +43,10 @@ weather_api_routes = [
 ]
 
 weather_api_env_vars = {
-  NODE_ENV           = "production"
-  API_VERSION        = "v1"
-  WEATHER_API_KEY    = "your-weather-api-key"
-  CACHE_TTL_SECONDS  = "300"
+  NODE_ENV          = "production"
+  API_VERSION       = "v1"
+  WEATHER_API_KEY   = "your-weather-api-key"
+  CACHE_TTL_SECONDS = "300"
 }
 
 weather_api_kv_namespaces = [

--- a/infrastructure/terraform/environments/staging.tfvars
+++ b/infrastructure/terraform/environments/staging.tfvars
@@ -4,4 +4,20 @@ environment = "staging"
 # MCP server-specific configurations are dynamically generated
 # based on affected applications. Add configurations here
 # using the pattern: {app_name}_routes, {app_name}_env_vars, etc.
-# where app_name is the sanitized project name (e.g., petstore_api) 
+# where app_name is the sanitized project name (e.g., petstore_api)
+
+# Petstore API configuration
+petstore_api_routes = []
+
+# Environment variables for petstore API
+petstore_api_env_vars = {
+  NODE_ENV    = "staging"
+  API_VERSION = "v1"
+  LOG_LEVEL   = "info"
+  CORS_ORIGIN = "*"
+  RATE_LIMIT  = "1000"
+}
+
+# Optional: KV namespaces and R2 buckets
+petstore_api_kv_namespaces = []
+petstore_api_r2_buckets    = [] 

--- a/infrastructure/terraform/modules/cloudflare-worker/main.tf
+++ b/infrastructure/terraform/modules/cloudflare-worker/main.tf
@@ -30,7 +30,7 @@ resource "cloudflare_workers_script" "worker" {
 
   # Environment variables (secrets)
   dynamic "plain_text_binding" {
-    for_each = var.environment_variables
+    for_each = try(tomap(var.environment_variables), {})
     content {
       name = plain_text_binding.key
       text = plain_text_binding.value
@@ -75,7 +75,7 @@ resource "cloudflare_workers_script" "worker" {
 }
 
 # Create routes for the worker
-resource "cloudflare_worker_route" "routes" {
+resource "cloudflare_workers_route" "routes" {
   for_each = { for idx, route in var.routes : idx => route }
 
   zone_id     = each.value.zone_id
@@ -84,7 +84,7 @@ resource "cloudflare_worker_route" "routes" {
 }
 
 # Create a custom domain for the worker (optional)
-resource "cloudflare_worker_domain" "domain" {
+resource "cloudflare_workers_domain" "domain" {
   count = var.custom_domain != null ? 1 : 0
 
   account_id = var.account_id

--- a/infrastructure/terraform/modules/cloudflare-worker/outputs.tf
+++ b/infrastructure/terraform/modules/cloudflare-worker/outputs.tf
@@ -9,9 +9,9 @@ output "worker_name" {
 }
 
 output "worker_routes" {
-  description = "Routes configured for the Worker"
+  description = "Routes configured for the worker"
   value = [
-    for route in cloudflare_worker_route.routes : {
+    for route in cloudflare_workers_route.routes : {
       pattern = route.pattern
       zone_id = route.zone_id
     }

--- a/infrastructure/terraform/terraform.tfvars.local.example
+++ b/infrastructure/terraform/terraform.tfvars.local.example
@@ -1,0 +1,11 @@
+# Example Cloudflare credentials for local development
+# Copy this file to terraform.tfvars.local and fill in your actual values
+
+# Your Cloudflare API token (40 characters)
+# Create at: https://dash.cloudflare.com/profile/api-tokens
+# Required permissions: Account:Cloudflare Workers Scripts:Edit
+cloudflare_api_token = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+# Your Cloudflare Account ID (32 characters)
+# Find in: Cloudflare Dashboard > Right sidebar > Account ID
+cloudflare_account_id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" 


### PR DESCRIPTION
- Modified Makefile to include a note for creating terraform.tfvars.local for local development.
- Adjusted formatting in mcp-server-config.example.tfvars for consistency.
- Added petstore API configuration to staging.tfvars.
- Updated resource names in cloudflare-worker module to use plural forms for consistency.